### PR TITLE
Fixes for REPO beta RPC changes.

### DIFF
--- a/Menu.cs
+++ b/Menu.cs
@@ -270,7 +270,9 @@ namespace RepoAdminMenu {
             addIntSlider(upgradesMenu, "Stamina", "", (v) => { PlayerUtil.upgradeStamina(avatar, v); }, 0, Configuration.MaxUpgradeLevel.Value, PlayerUtil.getUpgradeLevel("stamina", avatar));
             addIntSlider(upgradesMenu, "Strength", "", (v) => { PlayerUtil.upgradeStrength(avatar, v); }, 0, Configuration.MaxUpgradeLevel.Value, PlayerUtil.getUpgradeLevel("strength", avatar));
             addIntSlider(upgradesMenu, "Throw", "", (v) => { PlayerUtil.upgradeThrow(avatar, v); }, 0, Configuration.MaxUpgradeLevel.Value, PlayerUtil.getUpgradeLevel("throw", avatar));
-
+            addIntSlider(upgradesMenu, "Tumble Wings", "", (v) => { PlayerUtil.upgradeTumbleWings(avatar, v); }, 0, Configuration.MaxUpgradeLevel.Value, PlayerUtil.getUpgradeLevel("tumblewings", avatar));
+            addIntSlider(upgradesMenu, "Crouch Rest", "", (v) => { PlayerUtil.upgradeCrouchRest(avatar, v); }, 0, Configuration.MaxUpgradeLevel.Value, PlayerUtil.getUpgradeLevel("crouchrest", avatar));
+            
             openPage(upgradesMenu, "playerUpgrade");
         }
 

--- a/Patches/PunManagerPatch.cs
+++ b/Patches/PunManagerPatch.cs
@@ -6,19 +6,21 @@ namespace RepoAdminMenu.Patches {
     [HarmonyPatch(typeof(PunManager))]
     internal class PunManagerPatch {
 
-        [HarmonyPatch("UpdateHealthRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateHealthRightAway))]
         [HarmonyPrefix]
-        private static bool Prefix_UpdateHealthRightAway(ref string playerName) {
-            PlayerAvatar playerAvatar = SemiFunc.PlayerAvatarGetFromSteamID(playerName);
+        // ReSharper disable once InconsistentNaming
+        private static bool Prefix_UpdateHealthRightAway(ref string _steamID) {
+            PlayerAvatar playerAvatar = SemiFunc.PlayerAvatarGetFromSteamID(_steamID);
             if (playerAvatar == SemiFunc.PlayerAvatarLocal()) {
-                playerAvatar.playerHealth.maxHealth = 100 + (StatsManager.instance.playerUpgradeHealth[playerName] * 20);
+                playerAvatar.playerHealth.maxHealth = 100 + (StatsManager.instance.playerUpgradeHealth[_steamID] * 20);
                 playerAvatar.playerHealth.Heal(playerAvatar.playerHealth.maxHealth - playerAvatar.playerHealth.health, false);
             }
             return false;
         }
 
-        [HarmonyPatch("UpdateEnergyRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateEnergyRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateEnergyRightAway(ref string _steamID) {
             if (SemiFunc.PlayerAvatarGetFromSteamID(_steamID) == SemiFunc.PlayerAvatarLocal()) {
                 PlayerController.instance.EnergyStart = 40 + (StatsManager.instance.playerUpgradeStamina[_steamID] * 10f);
@@ -27,8 +29,9 @@ namespace RepoAdminMenu.Patches {
             return false;
         }
 
-        [HarmonyPatch("UpdateExtraJumpRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateExtraJumpRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateExtraJumpRightAway(ref string _steamID) {
             if (SemiFunc.PlayerAvatarGetFromSteamID(_steamID) == SemiFunc.PlayerAvatarLocal()) {
                 PlayerController.instance.JumpExtra = StatsManager.instance.playerUpgradeExtraJump[_steamID];
@@ -36,8 +39,9 @@ namespace RepoAdminMenu.Patches {
             return false;
         }
 
-        [HarmonyPatch("UpdateMapPlayerCountRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateMapPlayerCountRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool UpdateMapPlayerCountRightAway(ref string _steamID) {
             PlayerAvatar playerAvatar = SemiFunc.PlayerAvatarGetFromSteamID(_steamID);
             if (playerAvatar == SemiFunc.PlayerAvatarLocal()) {
@@ -46,15 +50,17 @@ namespace RepoAdminMenu.Patches {
             return false;
         }
 
-        [HarmonyPatch("UpdateTumbleLaunchRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateTumbleLaunchRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateTumbleLaunchRightAway(ref string _steamID) {
             SemiFunc.PlayerAvatarGetFromSteamID(_steamID).tumble.tumbleLaunch = StatsManager.instance.playerUpgradeLaunch[_steamID];
             return false;
         }
 
-        [HarmonyPatch("UpdateSprintSpeedRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateSprintSpeedRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateSprintSpeedRightAway(ref string _steamID) {
             if (SemiFunc.PlayerAvatarGetFromSteamID(_steamID) == SemiFunc.PlayerAvatarLocal()) {
                 PlayerController.instance.SprintSpeed = StatsManager.instance.playerUpgradeSpeed[_steamID];
@@ -63,8 +69,9 @@ namespace RepoAdminMenu.Patches {
             return false;
         }
 
-        [HarmonyPatch("UpdateGrabStrengthRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateGrabStrengthRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateGrabStrengthRightAway(ref string _steamID) {
             PlayerAvatar playerAvatar = SemiFunc.PlayerAvatarGetFromSteamID(_steamID);
             if (playerAvatar) {
@@ -73,8 +80,9 @@ namespace RepoAdminMenu.Patches {
             return false;
         }
 
-        [HarmonyPatch("UpdateThrowStrengthRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateThrowStrengthRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateThrowStrengthRightAway(ref string _steamID) {
             PlayerAvatar playerAvatar = SemiFunc.PlayerAvatarGetFromSteamID(_steamID);
             if (playerAvatar) {
@@ -83,8 +91,9 @@ namespace RepoAdminMenu.Patches {
             return false;
         }
 
-        [HarmonyPatch("UpdateGrabRangeRightAway")]
+        [HarmonyPatch(nameof(PunManager.UpdateGrabRangeRightAway))]
         [HarmonyPrefix]
+        // ReSharper disable once InconsistentNaming
         private static bool Prefix_UpdateGrabRangeRightAway(ref string _steamID) {
             PlayerAvatar playerAvatar = SemiFunc.PlayerAvatarGetFromSteamID(_steamID);
             if (playerAvatar) {

--- a/Utils/ItemUtil.cs
+++ b/Utils/ItemUtil.cs
@@ -10,7 +10,7 @@ namespace RepoAdminMenu.Utils {
 
         public static void Init() {
             items.Clear();
-            foreach (Item item in StatsManager.instance.GetItems()) {
+            foreach (Item item in StatsManager.instance.itemDictionary.Values) {
                 string name = item.name.Replace("Item ", string.Empty);
                 if (!items.ContainsKey(name))
                     items.Add(name, item);


### PR DESCRIPTION
This contains a few fixes for RPC and build issues on REPO's beta branch.

## Changes
### Non-Dev Overview
* No longer explodes on beta.
* Upgrades apply immediately to hosts and single-player games.
* Added support for Tumble Wings and Crouch Rest upgrades.

### Developer Stuff
* HarmonyPatches use `nameof()` to ensure members exist at compile-time.
* `StatsManager.GetItem()` was removed, we iterate the item dictionary bareback now.
* Added `PlayerUtil.SendStatUpdate()` to send `StatsManager.UpdateStat()` calls in a checked manner.
* Added re-implementation of `PunManager.Upgrade*RightAway()` methods so that level changes are reflected locally. Some RPC calls were added, where possible.
* Added Tumble Wings and Crouch Rest upgrade support

## A Note on Build Pipelines
Please note that locally, I use a jerry-rigged version of the REPOLib recommended build pipeline, and Rider as my IDE.  I have deliberately not included any of the build files (.csproj nor .sln), nor did I include the deletion of `AssemblyInfo.cs` that I had to do to fix build issues.  This may result in issues compiling on your end because I cannot reproduce your build environment without the solution or csproj files you used. Apologies if this causes any issues, but its unavoidable.
